### PR TITLE
Add `assert_err_eq!` macro

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-liberapay: svartalf
-patreon: svartalf
-custom: ["https://svartalf.info/donate/", "https://www.buymeacoffee.com/svartalf"]

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "line-length": false,
+    "no-duplicate-heading": {
+        "siblings_only": true
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2022-08-31
+
+### Added
+
+- `assert_err_eq!` macro. Thanks @Anders429!
+
 ## [0.6.0] - 2022-08-30
 
 Forked the [original project](https://github.com/svartalf/rust-claim) as the maintainer is unreachable at the moment. Renamed crate to `claims`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "claims"
 description = "Assertion macros"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["svartalf <self@svartalf.info>", "mattwilkinsonn <mattwilki17@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 categories = ["development-tools", "development-tools::testing", "no-std"]

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 > Missing assertion macros for Rust
 
-This is a fork of [rust-claim](https://github.com/svartalf/rust-claim). Big thanks to svartalf and Turbo87 for creating and working on the original library. I've created this fork to keep the library updated on crates.io and get around a versioning issue with [`autocfg`](https://github.com/cuviper/autocfg). If the original library starts being updated again i'll deprecate this one.
-
 [![Latest Version](https://img.shields.io/crates/v/claims.svg)](https://crates.io/crates/claims)
 [![Latest Version](https://docs.rs/claims/badge.svg)](https://docs.rs/claims)
 [![Build Status](https://github.com/mattwilkinsonn/rust-claims/workflows/Continuous%20integration/badge.svg)](https://github.com/mattwilkinsonn/rust-claims/actions)
 ![Apache 2.0 OR MIT licensed](https://img.shields.io/badge/license-Apache2.0%2FMIT-blue.svg)
 ![no-std compatible](https://img.shields.io/badge/no--std-compatible-brightgreen)
 ![Version compatibility](https://img.shields.io/badge/Rust-1.0%2B-blue)
+
+This is a fork of [rust-claim](https://github.com/svartalf/rust-claim). Big thanks to svartalf and Turbo87 for creating and working on the original library. I've created this fork to keep the library updated on crates.io and get around a versioning issue with [`autocfg`](https://github.com/cuviper/autocfg). If the original library starts being updated again i'll deprecate this one.
 
 This crate provides assertion macros that are missing in the Rust `libcore` / `libstd`:
 

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -14,7 +14,7 @@
 /// ## Examples
 ///
 /// ```rust
-/// # #[macro_use] extern crate claim;
+/// # #[macro_use] extern crate claims;
 /// # fn main() {
 /// let res: Result<(), i32> = Err(1);
 ///
@@ -28,7 +28,7 @@
 /// Value of `E` type from `Err(E)` will be returned from the macro call:
 ///
 /// ```rust
-/// # #[macro_use] extern crate claim;
+/// # #[macro_use] extern crate claims;
 /// # fn main() {
 /// let res: Result<(), i32> = Err(1);
 ///
@@ -40,7 +40,7 @@
 /// `Ok(..)` variant will cause panic:
 ///
 /// ```rust,should_panic
-/// # #[macro_use] extern crate claim;
+/// # #[macro_use] extern crate claims;
 /// # fn main() {
 /// let res: Result<(), i32> = Ok(());
 ///


### PR DESCRIPTION
This text is copied from https://github.com/svartalf/rust-claim/pull/8. Thanks to @Anders429!

Introduces an `assert_err_eq!` macro, which asserts that a `Result` value is an `Err` and that its contained value is equal to the provided value. Also defines a `debug_assert_err_eq!` macro.

This is very similar to the `assert_ok_eq!` macro, and I think this nicely fills out the macros provided by this library. Similarly, the `debug_assert_err_eq!` macro is very similar to the `debug_assert_ok_eq!` macro.