### PR TITLE
Propagate custom messages to `assert_eq` macro.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ github-actions = { repository = "mattwilkinsonn/rust-claims", workflow = "Contin
 
 [build-dependencies]
 autocfg = "1.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_task_poll)", "cfg(has_private_in_public_issue)", "cfg(rustc_1_6)", "cfg(rustc_1_26)"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ github-actions = { repository = "mattwilkinsonn/rust-claims", workflow = "Contin
 autocfg = "1.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_task_poll)", "cfg(has_private_in_public_issue)", "cfg(rustc_1_6)", "cfg(rustc_1_26)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_task_poll)", "cfg(has_private_in_public_issue)", "cfg(rustc_1_6)", "cfg(rustc_1_11)", "cfg(rustc_1_26)"] }

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,9 @@ fn main() {
     // Needed to enable `#![no_std]` only on rustc versions that support it (rustc 1.6.0 and up).
     cfg.emit_rustc_version(1, 6);
 
+    // Needed to enable custom error message propagation to `assert_eq`.
+    cfg.emit_rustc_version(1, 11);
+
     // Needed for `assert_matches!`' minimum rust version.
     cfg.emit_rustc_version(1, 26);
 

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -70,7 +70,7 @@ macro_rules! assert_err_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Err(t) => {
-                assert_eq!(t, $expected);
+                assert_eq!(t, $expected, $($arg)+);
                 t
             },
             ok @ Ok(..) => {
@@ -96,4 +96,15 @@ macro_rules! assert_err_eq {
 #[macro_export]
 macro_rules! debug_assert_err_eq {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::assert_err_eq!($($arg)*); })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::assert_err_eq;
+
+    #[test]
+    #[should_panic(expected = "foo")]
+    fn custom_message_propagation() {
+        let _ = assert_err_eq!(Err::<(), _>(1), 2, "foo");
+    }
 }

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -70,7 +70,14 @@ macro_rules! assert_err_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Err(t) => {
-                assert_eq!(t, $expected, $($arg)+);
+                #[cfg(rustc_1_11)]
+                {
+                    assert_eq!(t, $expected, $($arg)+);
+                }
+                #[cfg(not(rustc_1_11))]
+                {
+                    assert_eq!(t, $expected);
+                }
                 t
             },
             ok @ Ok(..) => {
@@ -101,6 +108,7 @@ macro_rules! debug_assert_err_eq {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {
         let _ = assert_err_eq!(Err::<(), _>(1), 2, "foo");

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -100,8 +100,6 @@ macro_rules! debug_assert_err_eq {
 
 #[cfg(test)]
 mod tests {
-    use crate::assert_err_eq;
-
     #[test]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -51,6 +51,7 @@
 /// [`Err(E)`]: https://doc.rust-lang.org/core/result/enum.Result.html#variant.Err
 /// [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
 /// [`debug_assert_err_eq!`]: ./macro.debug_assert_err_eq.html
+#[cfg(rustc_1_11)]
 #[macro_export]
 macro_rules! assert_err_eq {
     ($cond:expr, $expected:expr,) => {
@@ -70,9 +71,36 @@ macro_rules! assert_err_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Err(t) => {
-                #[cfg(rustc_1_11)]
                 assert_eq!(t, $expected, $($arg)+);
-                #[cfg(not(rustc_1_11))]
+                t
+            },
+            ok @ Ok(..) => {
+                panic!("assertion failed, expected Err(..), got {:?}: {}", ok, format_args!($($arg)+));
+            }
+        }
+    };
+}
+
+#[cfg(not(rustc_1_11))]
+#[macro_export]
+macro_rules! assert_err_eq {
+    ($cond:expr, $expected:expr,) => {
+        $crate::assert_err_eq!($cond, $expected);
+    };
+    ($cond:expr, $expected:expr) => {
+        match $cond {
+            Err(t) => {
+                assert_eq!(t, $expected);
+                t
+            },
+            ok @ Ok(..) => {
+                panic!("assertion failed, expected Err(..), got {:?}", ok);
+            }
+        }
+    };
+    ($cond:expr, $expected:expr, $($arg:tt)+) => {
+        match $cond {
+            Err(t) => {
                 assert_eq!(t, $expected);
                 t
             },

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -71,13 +71,9 @@ macro_rules! assert_err_eq {
         match $cond {
             Err(t) => {
                 #[cfg(rustc_1_11)]
-                {
-                    assert_eq!(t, $expected, $($arg)+);
-                }
+                assert_eq!(t, $expected, $($arg)+);
                 #[cfg(not(rustc_1_11))]
-                {
-                    assert_eq!(t, $expected);
-                }
+                assert_eq!(t, $expected);
                 t
             },
             ok @ Ok(..) => {

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -105,7 +105,10 @@ macro_rules! debug_assert_err_eq {
 #[cfg(not(has_private_in_public_issue))]
 mod tests {
     #[test]
-    #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]
+    #[cfg_attr(
+        not(rustc_1_11),
+        ignore = "custom message propagation is only available in rustc 1.11.0 or later"
+    )]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {
         let _ = assert_err_eq!(Err::<(), _>(1), 2, "foo");

--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -102,6 +102,7 @@ macro_rules! debug_assert_err_eq {
 }
 
 #[cfg(test)]
+#[cfg(not(has_private_in_public_issue))]
 mod tests {
     #[test]
     #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -51,6 +51,7 @@
 /// [`Ok(T)`]: https://doc.rust-lang.org/core/result/enum.Result.html#variant.Ok
 /// [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
 /// [`debug_assert_ok_eq!`]: ./macro.debug_assert_ok_eq.html
+#[cfg(rustc_1_11)]
 #[macro_export]
 macro_rules! assert_ok_eq {
     ($cond:expr, $expected:expr,) => {
@@ -70,9 +71,35 @@ macro_rules! assert_ok_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Ok(t) => {
-                #[cfg(rustc_1_11)]
                 assert_eq!(t, $expected, $($arg)+);
-                #[cfg(not(rustc_1_11))]
+            },
+            e @ Err(..) => {
+                panic!("assertion failed, expected Ok(..), got {:?}: {}", e, format_args!($($arg)+));
+            }
+        }
+    };
+}
+
+#[cfg(not(rustc_1_11))]
+#[macro_export]
+macro_rules! assert_ok_eq {
+    ($cond:expr, $expected:expr,) => {
+        $crate::assert_ok_eq!($cond, $expected);
+    };
+    ($cond:expr, $expected:expr) => {
+        match $cond {
+            Ok(t) => {
+                assert_eq!(t, $expected);
+                t
+            },
+            e @ Err(..) => {
+                panic!("assertion failed, expected Ok(..), got {:?}", e);
+            }
+        }
+    };
+    ($cond:expr, $expected:expr, $($arg:tt)+) => {
+        match $cond {
+            Ok(t) => {
                 assert_eq!(t, $expected);
                 t
             },

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -100,8 +100,6 @@ macro_rules! debug_assert_ok_eq {
 
 #[cfg(test)]
 mod tests {
-    use crate::assert_ok_eq;
-
     #[test]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -105,7 +105,10 @@ macro_rules! debug_assert_ok_eq {
 #[cfg(not(has_private_in_public_issue))]
 mod tests {
     #[test]
-    #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]
+    #[cfg_attr(
+        not(rustc_1_11),
+        ignore = "custom message propagation is only available in rustc 1.11.0 or later"
+    )]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {
         let _ = assert_ok_eq!(Ok::<_, ()>(1), 2, "foo");

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -70,7 +70,14 @@ macro_rules! assert_ok_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Ok(t) => {
-                assert_eq!(t, $expected, $($arg)+);
+                #[cfg(rustc_1_11)]
+                {
+                    assert_eq!(t, $expected, $($arg)+);
+                }
+                #[cfg(not(rustc_1_11))]
+                {
+                    assert_eq!(t, $expected);
+                }
                 t
             },
             e @ Err(..) => {
@@ -101,6 +108,7 @@ macro_rules! debug_assert_ok_eq {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {
         let _ = assert_ok_eq!(Ok::<_, ()>(1), 2, "foo");

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -102,6 +102,7 @@ macro_rules! debug_assert_ok_eq {
 }
 
 #[cfg(test)]
+#[cfg(not(has_private_in_public_issue))]
 mod tests {
     #[test]
     #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -72,6 +72,7 @@ macro_rules! assert_ok_eq {
         match $cond {
             Ok(t) => {
                 assert_eq!(t, $expected, $($arg)+);
+                t
             },
             e @ Err(..) => {
                 panic!("assertion failed, expected Ok(..), got {:?}: {}", e, format_args!($($arg)+));

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -71,13 +71,9 @@ macro_rules! assert_ok_eq {
         match $cond {
             Ok(t) => {
                 #[cfg(rustc_1_11)]
-                {
-                    assert_eq!(t, $expected, $($arg)+);
-                }
+                assert_eq!(t, $expected, $($arg)+);
                 #[cfg(not(rustc_1_11))]
-                {
-                    assert_eq!(t, $expected);
-                }
+                assert_eq!(t, $expected);
                 t
             },
             e @ Err(..) => {

--- a/src/assert_ok_eq.rs
+++ b/src/assert_ok_eq.rs
@@ -70,7 +70,7 @@ macro_rules! assert_ok_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Ok(t) => {
-                assert_eq!(t, $expected);
+                assert_eq!(t, $expected, $($arg)+);
                 t
             },
             e @ Err(..) => {
@@ -96,4 +96,15 @@ macro_rules! assert_ok_eq {
 #[macro_export]
 macro_rules! debug_assert_ok_eq {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::assert_ok_eq!($($arg)*); })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::assert_ok_eq;
+
+    #[test]
+    #[should_panic(expected = "foo")]
+    fn custom_message_propagation() {
+        let _ = assert_ok_eq!(Ok::<_, ()>(1), 2, "foo");
+    }
 }

--- a/src/assert_some_eq.rs
+++ b/src/assert_some_eq.rs
@@ -39,6 +39,7 @@
 /// [`Some(T)`]: https://doc.rust-lang.org/core/option/enum.Option.html#variant.Some
 /// [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
 /// [`debug_assert_some_eq!`]: ./macro.debug_assert_some_eq.html
+#[cfg(rustc_1_11)]
 #[macro_export]
 macro_rules! assert_some_eq {
     ($cond:expr, $expected:expr,) => {
@@ -58,9 +59,36 @@ macro_rules! assert_some_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Some(t) => {
-                #[cfg(rustc_1_11)]
                 assert_eq!(t, $expected, $($arg)+);
-                #[cfg(not(rustc_1_11))]
+                t
+            },
+            None => {
+                panic!("assertion failed, expected Some(..), got None: {}", format_args!($($arg)+));
+            }
+        }
+    };
+}
+
+#[cfg(not(rustc_1_11))]
+#[macro_export]
+macro_rules! assert_some_eq {
+    ($cond:expr, $expected:expr,) => {
+        $crate::assert_some_eq!($cond, $expected);
+    };
+    ($cond:expr, $expected:expr) => {
+        match $cond {
+            Some(t) => {
+                assert_eq!(t, $expected);
+                t
+            },
+            None => {
+                panic!("assertion failed, expected Some(..), got None");
+            }
+        }
+    };
+    ($cond:expr, $expected:expr, $($arg:tt)+) => {
+        match $cond {
+            Some(t) => {
                 assert_eq!(t, $expected);
                 t
             },

--- a/src/assert_some_eq.rs
+++ b/src/assert_some_eq.rs
@@ -59,13 +59,9 @@ macro_rules! assert_some_eq {
         match $cond {
             Some(t) => {
                 #[cfg(rustc_1_11)]
-                {
-                    assert_eq!(t, $expected, $($arg)+);
-                }
+                assert_eq!(t, $expected, $($arg)+);
                 #[cfg(not(rustc_1_11))]
-                {
-                    assert_eq!(t, $expected);
-                }
+                assert_eq!(t, $expected);
                 t
             },
             None => {

--- a/src/assert_some_eq.rs
+++ b/src/assert_some_eq.rs
@@ -88,8 +88,6 @@ macro_rules! debug_assert_some_eq {
 
 #[cfg(test)]
 mod tests {
-    use crate::assert_some_eq;
-
     #[test]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {

--- a/src/assert_some_eq.rs
+++ b/src/assert_some_eq.rs
@@ -93,7 +93,10 @@ macro_rules! debug_assert_some_eq {
 #[cfg(not(has_private_in_public_issue))]
 mod tests {
     #[test]
-    #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]
+    #[cfg_attr(
+        not(rustc_1_11),
+        ignore = "custom message propagation is only available in rustc 1.11.0 or later"
+    )]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {
         let _ = assert_some_eq!(Some(1), 2, "foo");

--- a/src/assert_some_eq.rs
+++ b/src/assert_some_eq.rs
@@ -90,6 +90,7 @@ macro_rules! debug_assert_some_eq {
 }
 
 #[cfg(test)]
+#[cfg(not(has_private_in_public_issue))]
 mod tests {
     #[test]
     #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]

--- a/src/assert_some_eq.rs
+++ b/src/assert_some_eq.rs
@@ -58,7 +58,14 @@ macro_rules! assert_some_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Some(t) => {
-                assert_eq!(t, $expected, $($arg)+);
+                #[cfg(rustc_1_11)]
+                {
+                    assert_eq!(t, $expected, $($arg)+);
+                }
+                #[cfg(not(rustc_1_11))]
+                {
+                    assert_eq!(t, $expected);
+                }
                 t
             },
             None => {
@@ -89,6 +96,7 @@ macro_rules! debug_assert_some_eq {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg_attr(not(rustc_1_11), ignore = "custom message propagation is only available in rustc 1.11.0 or later")]
     #[should_panic(expected = "foo")]
     fn custom_message_propagation() {
         let _ = assert_some_eq!(Some(1), 2, "foo");

--- a/src/assert_some_eq.rs
+++ b/src/assert_some_eq.rs
@@ -58,7 +58,7 @@ macro_rules! assert_some_eq {
     ($cond:expr, $expected:expr, $($arg:tt)+) => {
         match $cond {
             Some(t) => {
-                assert_eq!(t, $expected);
+                assert_eq!(t, $expected, $($arg)+);
                 t
             },
             None => {
@@ -84,4 +84,15 @@ macro_rules! assert_some_eq {
 #[macro_export]
 macro_rules! debug_assert_some_eq {
     ($($arg:tt)*) => (if core::cfg!(debug_assertions) { $crate::assert_some_eq!($($arg)*); })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::assert_some_eq;
+
+    #[test]
+    #[should_panic(expected = "foo")]
+    fn custom_message_propagation() {
+        let _ = assert_some_eq!(Some(1), 2, "foo");
+    }
 }


### PR DESCRIPTION
I noticed that custom messages weren't propagated when using things like `assert_ok_eq!` in some cases. Specifically, whenever the internal `assert_eq!` macro was reached, the custom messages were dropped. On investigation, it seemed this was a pretty simple fix. Interestingly, I noticed `assert_ready_eq!` already propagated the message correctly.

A few notes:

- The propagation requires `rustc 1.11.0` or later. I made it so that versions prior simply operate without propagating the message.
- You'll notice I basically copy-pasted the macro in two different forms. That's because up until `rustc 1.11.0` `cfg` attributes were evaluated differently, causing the `assert_eq!` macro to be evaluated every time. To fix this, I had to put the whole `macro_rules!` definition behind a `cfg` attribute.
- If we want to make it less complicated, we could up the MSRV for these macros. `rustc 1.11.0` is nearly 8 years old at this point, but for now I've kept the compatibility so that we can release this as a patch. 

Also, what do you think about [detaching this fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/detaching-a-fork) from the original repository, so that bug reports can be filed here directly? It's been nearly two years, and it doesn't seem the original maintainer is coming back to it any time soon.